### PR TITLE
Example: Enable C++11 and add include path

### DIFF
--- a/Example/CMakeLists.txt
+++ b/Example/CMakeLists.txt
@@ -2,8 +2,12 @@ project(libHAPExample)
 cmake_minimum_required(VERSION 3.7)
 
 add_executable(hap_showcase "main.cpp")
-target_link_libraries(hap_showcase 
-    PUBLIC 
-    HAP::HAP )
+set_target_properties(hap_showcase PROPERTIES CXX_STANDARD 11)
+target_include_directories(hap_showcase
+	PRIVATE
+	${DNSSD_INCLUDE_DIRS} )
+target_link_libraries(hap_showcase
+	PUBLIC
+	HAP::HAP )
 
 install(TARGETS hap_showcase DESTINATION ${PROJECT_SOURCE_DIR}/..)


### PR DESCRIPTION
For older compilers C++11 always needs to be enabled explictly.
If dns_sd.h is not found in the default include folders,
add the path to it explicitly for the Example.